### PR TITLE
Enable default request read timeout to be overridden. 

### DIFF
--- a/lib/paymill.rb
+++ b/lib/paymill.rb
@@ -14,6 +14,7 @@ module Paymill
   @@api_version = API_VERSION
   @@api_port    = Net::HTTP.https_default_port
   @@logger      = Logger.new(STDOUT)
+  @@timeout     = nil
 
   autoload :Base,             "paymill/base"
   autoload :Client,           "paymill/client"
@@ -114,6 +115,21 @@ module Paymill
   def self.logger=(logger)
     @@logger = logger
   end
+
+  # Returns the current timeout (in seconds)
+  #
+  # @return [Integer] timeout The request timeout (in seconds) or nil
+  def self.timeout
+    @@timeout
+  end
+
+  # Sets the timeout for requests
+  #
+  # @param [Integer] timeout The request timeout (in seconds)
+  def self.timeout=(timeout)
+    @@timeout = timeout
+  end
+
 
   # Makes a request against the Paymill API
   #

--- a/lib/paymill/request/connection.rb
+++ b/lib/paymill/request/connection.rb
@@ -9,8 +9,9 @@ module Paymill
       end
 
       def setup_https
-        @https             = Net::HTTP.new(Paymill.api_base, Paymill.api_port)
-        @https.use_ssl     = true
+        @https              = Net::HTTP.new(Paymill.api_base, Paymill.api_port)
+        @https.use_ssl      = true
+        @https.read_timeout = Paymill.timeout if Paymill.timeout
       end
 
       def request
@@ -52,6 +53,7 @@ module Paymill
       def current_time
         Time.now.utc.strftime("%d/%b/%Y %H:%M:%S %Z")
       end
+
     end
   end
 end

--- a/spec/paymill/request/connection_spec.rb
+++ b/spec/paymill/request/connection_spec.rb
@@ -2,12 +2,32 @@ require "spec_helper"
 
 describe Paymill::Request::Connection do
   describe "#setup_https" do
+    let(:default_timeout) { 60 }
+
     it "creates a https object" do
       connection = Paymill::Request::Connection.new(nil)
 
       connection.setup_https
 
       connection.https.should_not be_nil
+    end
+
+    it "creates a https object with the default timeout" do
+      expect(Paymill.timeout).to  be_nil
+      connection = Paymill::Request::Connection.new(nil)
+      connection.setup_https
+
+      expect(connection.https).not_to          be_nil
+      expect(connection.https.read_timeout).to eq default_timeout
+    end
+
+    it "creates a https object with the default timeout" do
+      Paymill.timeout = 65 # seconds
+      connection = Paymill::Request::Connection.new(nil)
+      connection.setup_https
+
+      expect(connection.https).not_to          be_nil
+      expect(connection.https.read_timeout).to eq 65
     end
   end
 

--- a/spec/paymill_spec.rb
+++ b/spec/paymill_spec.rb
@@ -58,5 +58,12 @@ describe Paymill do
       Paymill.logger = logger
       expect(Paymill.logger).to eq logger
     end
+
+    it 'allows you to set the request timeout (in seconds)' do
+      Paymill.timeout = 65 # secs
+      expect(Paymill.timeout).to  eq 65
+      Paymill.timeout = nil
+      expect(Paymill.timeout).to  be_nil
+    end
   end
 end


### PR DESCRIPTION
Adds attribute accessors to Paymill 'timeout'.
Overrides default of 60s if 'timeout' has been set.